### PR TITLE
Adding support for private cloud

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ Other options that you can set include:
  * **public_ip**: optional; set to `pool` if you want Oracle Cloud to assign an IP from the default pool, or specify an existing IP Reservation name
  * **wait_time**: optional; number of seconds to wait for a server to start.  Defaults to 600.
  * **refresh_time**: optional; number of seconds sleep between checks on whether a server has started.  Defaults to 2.
+ * **private_cloud**: optional; set to `true` if the API endpoint you are using is part of an Oracle Cloud private cloud you are running behind your company's firewall. This is required due to the differences in identity_domain handling between the public and private cloud offerings.
 
 All of these settings can be set per-platform, as shown above, or can be set globally in the `driver` section of your .kitchen.yml:
 

--- a/lib/kitchen/driver/oraclecloud.rb
+++ b/lib/kitchen/driver/oraclecloud.rb
@@ -41,6 +41,7 @@ module Kitchen
       default_config :description, nil
       default_config :project_name, nil
       default_config :public_ip, nil
+      default_config :private_cloud, false
 
       def name
         'OracleCloud'
@@ -94,7 +95,8 @@ module Kitchen
           password:        config[:password],
           api_url:         config[:api_url],
           identity_domain: config[:identity_domain],
-          verify_ssl:      config[:verify_ssl]
+          verify_ssl:      config[:verify_ssl],
+          private_cloud:   config[:private_cloud]
         )
       end
 

--- a/spec/oraclecloud_spec.rb
+++ b/spec/oraclecloud_spec.rb
@@ -38,7 +38,8 @@ describe Kitchen::Driver::Oraclecloud do
       identity_domain: 'test_domain',
       shape:           'test_shape',
       image:           'test_image',
-      verify_ssl:      true
+      verify_ssl:      true,
+      private_cloud:   false
     }
   end
 


### PR DESCRIPTION
Due to a difference between how the identity_domain is handled between
the public and private cloud offerings, the underlying API client gem
requires knowing whether the API endpoint is on a private cloud or not.
This change allows a user to enable private cloud support.